### PR TITLE
feat: add integration tests for auth workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5316,14 +5316,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -6150,9 +6150,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -7913,10 +7913,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8837,9 +8840,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/server/src/test/java/de/tum/cit/memo/controller/AuthControllerIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/memo/controller/AuthControllerIntegrationTest.java
@@ -1,0 +1,161 @@
+package de.tum.cit.memo.controller;
+
+import de.tum.cit.memo.AbstractIntegrationTest;
+import de.tum.cit.memo.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SuppressWarnings("null")
+@Sql(
+    statements = {
+        "DELETE FROM competency_relationships_votes",
+        "DELETE FROM competency_resource_links",
+        "DELETE FROM competency_relationships",
+        "DELETE FROM users"
+    },
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
+class AuthControllerIntegrationTest extends AbstractIntegrationTest {
+
+    @MockitoBean
+    JwtDecoder jwtDecoder;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("GET /api/auth/me — unauthenticated")
+    class Unauthenticated {
+
+        @Test
+        @DisplayName("should return 401 when no Bearer token is provided")
+        void shouldReturn401WhenNoTokenProvided() throws Exception {
+            mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/auth/me — first login")
+    class FirstLogin {
+
+        @Test
+        @DisplayName("should create a new user and return the Keycloak subject as id")
+        void shouldCreateNewUserAndReturnSubjectAsId() throws Exception {
+            String sub = "kcid-first-login-001";
+
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "alice@tum.de"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(sub))
+                .andExpect(jsonPath("$.role").value("USER"));
+        }
+
+        @Test
+        @DisplayName("should persist the new user to the database on first login")
+        void shouldPersistNewUserToDatabase() throws Exception {
+            String sub = "kcid-first-login-002";
+
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "bob@tum.de"))))
+                .andExpect(status().isOk());
+
+            assertThat(userRepository.findById(sub)).isPresent();
+        }
+
+        @Test
+        @DisplayName("should assign USER role by default on first login")
+        void shouldAssignUserRoleByDefault() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-first-login-003").claim("email", "carol@tum.de"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("USER"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/auth/me — returning user")
+    class ReturningUser {
+
+        @Test
+        @DisplayName("should return the same user on subsequent logins without creating duplicates")
+        void shouldReturnSameUserWithoutDuplicates() throws Exception {
+            String sub = "kcid-returning-user-001";
+
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@tum.de"))))
+                .andExpect(status().isOk());
+
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@tum.de"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(sub))
+                .andExpect(jsonPath("$.role").value("USER"));
+
+            assertThat(userRepository.count()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/auth/me — domain restriction")
+    class DomainRestriction {
+
+        @Test
+        @DisplayName("should return 403 when email domain is not on the allowlist")
+        void shouldReturn403ForForbiddenEmailDomain() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-blocked-001").claim("email", "user@gmail.com"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").exists());
+        }
+
+        @Test
+        @DisplayName("should return 403 when the email claim is absent and domain restriction is active")
+        void shouldReturn403WhenEmailClaimMissing() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-no-email-001"))))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("should return 200 for an email on a permitted university domain")
+        void shouldReturn200ForAllowedDomain() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-allowed-001").claim("email", "student@tum.de"))))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("should match allowed domain case-insensitively")
+        void shouldMatchDomainCaseInsensitively() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-allowed-002").claim("email", "student@TUM.DE"))))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("should return 403 for an email address without an @ symbol")
+        void shouldReturn403ForMalformedEmail() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-malformed-001").claim("email", "not-an-email"))))
+                .andExpect(status().isForbidden());
+        }
+    }
+}

--- a/server/src/test/java/de/tum/cit/memo/controller/AuthControllerIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/memo/controller/AuthControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SpringBootTest(properties = "memo.allowed-email-domains=example.test")
 @AutoConfigureMockMvc
 @SuppressWarnings("null")
 @Sql(
@@ -62,7 +64,7 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
             String sub = "kcid-first-login-001";
 
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "alice@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "alice@example.test"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(sub))
                 .andExpect(jsonPath("$.role").value("USER"));
@@ -74,7 +76,7 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
             String sub = "kcid-first-login-002";
 
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "bob@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "bob@example.test"))))
                 .andExpect(status().isOk());
 
             assertThat(userRepository.findById(sub)).isPresent();
@@ -84,7 +86,7 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("should assign USER role by default on first login")
         void shouldAssignUserRoleByDefault() throws Exception {
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject("kcid-first-login-003").claim("email", "carol@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject("kcid-first-login-003").claim("email", "carol@example.test"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.role").value("USER"));
         }
@@ -100,11 +102,11 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
             String sub = "kcid-returning-user-001";
 
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@example.test"))))
                 .andExpect(status().isOk());
 
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject(sub).claim("email", "dave@example.test"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(sub))
                 .andExpect(jsonPath("$.role").value("USER"));
@@ -138,7 +140,7 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("should return 200 for an email on a permitted university domain")
         void shouldReturn200ForAllowedDomain() throws Exception {
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject("kcid-allowed-001").claim("email", "student@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject("kcid-allowed-001").claim("email", "student@example.test"))))
                 .andExpect(status().isOk());
         }
 
@@ -146,7 +148,7 @@ class AuthControllerIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("should match allowed domain case-insensitively")
         void shouldMatchDomainCaseInsensitively() throws Exception {
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject("kcid-allowed-002").claim("email", "student@TUM.DE"))))
+                    .with(jwt().jwt(j -> j.subject("kcid-allowed-002").claim("email", "student@EXAMPLE.TEST"))))
                 .andExpect(status().isOk());
         }
 

--- a/server/src/test/java/de/tum/cit/memo/repository/UserRepositoryTest.java
+++ b/server/src/test/java/de/tum/cit/memo/repository/UserRepositoryTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -73,18 +72,15 @@ class UserRepositoryTest extends AbstractRepositoryTest {
             userRepository.saveAndFlush(user1);
 
             User user2 = createUser("User Two", "same@example.com", UserRole.USER);
-            userRepository.save(user2);
+            userRepository.saveAndFlush(user2);
 
             // The email constraint is DEFERRABLE INITIALLY DEFERRED (V9 migration), so it is only
             // checked at commit time. Force an immediate check before the transaction rolls back.
             // The native query bypasses Spring's exception translator, so Hibernate's
-            // ConstraintViolationException is thrown directly rather than the Spring wrapper.
+            // ConstraintViolationException is thrown directly instead of the Spring wrapper.
             assertThatThrownBy(() ->
                 entityManager.createNativeQuery("SET CONSTRAINTS users_email_key IMMEDIATE").executeUpdate()
-            ).isInstanceOfAny(
-                DataIntegrityViolationException.class,
-                org.hibernate.exception.ConstraintViolationException.class
-            );
+            ).isInstanceOf(org.hibernate.exception.ConstraintViolationException.class);
         }
 
         @Test

--- a/server/src/test/java/de/tum/cit/memo/repository/UserRepositoryTest.java
+++ b/server/src/test/java/de/tum/cit/memo/repository/UserRepositoryTest.java
@@ -73,9 +73,18 @@ class UserRepositoryTest extends AbstractRepositoryTest {
             userRepository.saveAndFlush(user1);
 
             User user2 = createUser("User Two", "same@example.com", UserRole.USER);
+            userRepository.save(user2);
 
-            assertThatThrownBy(() -> userRepository.saveAndFlush(user2))
-                .isInstanceOf(DataIntegrityViolationException.class);
+            // The email constraint is DEFERRABLE INITIALLY DEFERRED (V9 migration), so it is only
+            // checked at commit time. Force an immediate check before the transaction rolls back.
+            // The native query bypasses Spring's exception translator, so Hibernate's
+            // ConstraintViolationException is thrown directly rather than the Spring wrapper.
+            assertThatThrownBy(() ->
+                entityManager.createNativeQuery("SET CONSTRAINTS users_email_key IMMEDIATE").executeUpdate()
+            ).isInstanceOfAny(
+                DataIntegrityViolationException.class,
+                org.hibernate.exception.ConstraintViolationException.class
+            );
         }
 
         @Test

--- a/server/src/test/java/de/tum/cit/memo/security/SecurityConfigIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/memo/security/SecurityConfigIntegrationTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -16,6 +18,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@SpringBootTest(properties = "memo.allowed-email-domains=example.test")
 @AutoConfigureMockMvc
 @SuppressWarnings("null")
 class SecurityConfigIntegrationTest extends AbstractIntegrationTest {
@@ -65,9 +68,18 @@ class SecurityConfigIntegrationTest extends AbstractIntegrationTest {
 
         @Test
         @DisplayName("should return 200 for a protected endpoint with a valid token")
+        @Sql(
+            statements = {
+                "DELETE FROM competency_relationships_votes",
+                "DELETE FROM competency_resource_links",
+                "DELETE FROM competency_relationships",
+                "DELETE FROM users"
+            },
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+        )
         void shouldReturn200ForProtectedEndpointWithValidToken() throws Exception {
             mockMvc.perform(get("/api/auth/me")
-                    .with(jwt().jwt(j -> j.subject("kcid-security-001").claim("email", "test@tum.de"))))
+                    .with(jwt().jwt(j -> j.subject("kcid-security-001").claim("email", "test@example.test"))))
                 .andExpect(status().isOk());
         }
     }

--- a/server/src/test/java/de/tum/cit/memo/security/SecurityConfigIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/memo/security/SecurityConfigIntegrationTest.java
@@ -1,0 +1,97 @@
+package de.tum.cit.memo.security;
+
+import de.tum.cit.memo.AbstractIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SuppressWarnings("null")
+class SecurityConfigIntegrationTest extends AbstractIntegrationTest {
+
+    @MockitoBean
+    JwtDecoder jwtDecoder;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("public endpoints")
+    class PublicEndpoints {
+
+        @Test
+        @DisplayName("should allow unauthenticated access to Swagger UI")
+        void shouldPermitSwaggerUiWithoutAuth() throws Exception {
+            mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("should allow unauthenticated access to OpenAPI docs")
+        void shouldPermitOpenApiDocsWithoutAuth() throws Exception {
+            mockMvc.perform(get("/api-docs"))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("should allow unauthenticated access to actuator health endpoint")
+        void shouldPermitHealthEndpointWithoutAuth() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("protected endpoints")
+    class ProtectedEndpoints {
+
+        @Test
+        @DisplayName("should return 401 for any protected endpoint without a token")
+        void shouldReturn401ForProtectedEndpointWithoutAuth() throws Exception {
+            mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("should return 200 for a protected endpoint with a valid token")
+        void shouldReturn200ForProtectedEndpointWithValidToken() throws Exception {
+            mockMvc.perform(get("/api/auth/me")
+                    .with(jwt().jwt(j -> j.subject("kcid-security-001").claim("email", "test@tum.de"))))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("CORS preflight")
+    class CorsPreflight {
+
+        @Test
+        @DisplayName("should allow OPTIONS preflight requests from permitted origins without auth")
+        void shouldPermitPreflightFromAllowedOrigin() throws Exception {
+            mockMvc.perform(options("/api/auth/me")
+                    .header("Origin", "http://localhost:3000")
+                    .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("should include CORS headers in the preflight response")
+        void shouldIncludeCorsHeadersInPreflightResponse() throws Exception {
+            mockMvc.perform(options("/api/auth/me")
+                    .header("Origin", "http://localhost:3000")
+                    .header("Access-Control-Request-Method", "GET"))
+                .andExpect(header().exists("Access-Control-Allow-Origin"));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds integration tests for the authentication workflows, covering the `/api/auth/me` endpoint and Spring Security configuration. Tests verify JWT-based login flows, user creation/idempotency, email domain restriction enforcement, public vs. protected endpoint access, and CORS preflight handling.

Also fixes a pre-existing broken test in `UserRepositoryTest` caused by migration V9 changing the email unique constraint to `DEFERRABLE INITIALLY DEFERRED`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting changes (no functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] 🔧 Configuration changes
- [x] 🧪 Test additions or modifications
- [ ] 🚀 Deployment/DevOps changes

## Related Issues

<!-- Link to related issues using "Fixes #123" or "Closes #123" -->

- Fixes #46

## Changes Made

<!-- Describe the changes made in detail -->

- Client: —
- Server:
  - Added `AuthControllerIntegrationTest` — 10 integration tests for `GET /api/auth/me` covering unauthenticated access (401), first-login user creation, idempotent returning-user login, and email domain restriction (allowed domain, forbidden domain, missing email claim, case-insensitive domain match, malformed email)
  - Added `SecurityConfigIntegrationTest` — 7 integration tests for Spring Security configuration covering public endpoints (Swagger UI, OpenAPI docs, actuator health), protected endpoint access (401 without token, 200 with token), and CORS preflight (OPTIONS allowed, response headers present)
  - Fixed `UserRepositoryTest.shouldEnforceUniqueEmail` — the `users.email` constraint was changed to `DEFERRABLE INITIALLY DEFERRED` in migration V9, which meant the constraint was never triggered inside a `@DataJpaTest` rollback transaction. The test now forces an immediate constraint check via `SET CONSTRAINTS users_email_key IMMEDIATE`
- Database: —
- Other: Uses `@MockitoBean JwtDecoder` to provide a stub bean so the Spring Security OAuth2 filter chain initialises without a running Keycloak instance; mock JWT tokens are injected via `SecurityMockMvcRequestPostProcessors.jwt()` from `spring-security-test`

## Testing

<!-- Describe how you tested your changes -->

### Test Cases

<!-- List the test cases you've verified -->

- [x] Existing functionality still works
- [x] New functionality works as expected
- [x] Edge cases handled appropriately

### Manual Testing

<!-- Describe manual testing performed -->

- [x] Tested in development environment
- [ ] Tested with different user roles/permissions (if applicable)

All 127 tests pass with `./server-manage.sh build` (Checkstyle + Spotless + full test suite).

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

### Before

<!-- Screenshots/videos of the current behavior -->

### After

<!-- Screenshots/videos of the new behavior -->